### PR TITLE
Debug trap - bash 5 compatibility

### DIFF
--- a/26-debugging.sh
+++ b/26-debugging.sh
@@ -24,7 +24,7 @@ echo "
 ###############################################
 "
 
-trap '(read -p "[$BASH_SOURCE:$LINENO] $BASH_COMMAND ") ' DEBUG
+trap 'read -p "[$BASH_SOURCE:$LINENO] $BASH_COMMAND "' DEBUG
 
 echo "it makes us press enter to confirm before every line of code"
 


### PR DESCRIPTION
Hi,

In bash 5 the debug trap does not work correctly due to the subshell `(...)`.
It's not a bash bug but an expected behaviour see [question](https://lists.gnu.org/archive/html/bug-bash/2021-11/msg00055.html), [answer](https://lists.gnu.org/archive/html/bug-bash/2021-11/msg00058.html).

> the subshell `forgets' that it's executing as part of the DEBUG trap

What was the intention behind the subshell by the way? so that it does not pollute the current shell?
I think we should be fine even without it.

---
How to reproduce if you don't have bash 5:
```shell
$ docker run -it --rm -v $PWD:/vol bash:5 bash /vol/26-debugging.sh
...
###############################################
## Example 26.2:                              #
## trap lets us make a fancy step debugger #
###############################################

[/vol/26-debugging.sh:29] read -p "[$BASH_SOURCE:$LINENO] $BASH_COMMAND "
it makes us press enter to confirm before every line of code
[/vol/26-debugging.sh:31] read -p "[$BASH_SOURCE:$LINENO] $BASH_COMMAND "
[/vol/26-debugging.sh:33] read -p "[$BASH_SOURCE:$LINENO] $BASH_COMMAND "
...
```